### PR TITLE
Create MPI dependency for MPI build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libensemble" %}
 {% set version = "0.6.0" %}
-{% set build = 3 %}
+{% set build = 4 %}
 {% set sha256 = "bf0483a05bfac383f82fd2a79ca5151af7a2337e07b2392eee2e6396c250357e" %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - python
     - setuptools
   run:
+    - {{ mpi }}  # [mpi != 'nompi']
     - nlopt
     - numpy
     - petsc4py   # [mpi != 'nompi' and not win]


### PR DESCRIPTION
Trying to force libensemble to bring in correct MPI library.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
